### PR TITLE
Remove view transition meta tag injection

### DIFF
--- a/library/src/plugins/official/browser/attributes/viewTransition.ts
+++ b/library/src/plugins/official/browser/attributes/viewTransition.ts
@@ -17,21 +17,6 @@ export const ViewTransition: AttributePlugin = {
   name: 'viewTransition',
   keyReq: Requirement.Denied,
   valReq: Requirement.Must,
-  onGlobalInit() {
-    let hasViewTransitionMeta = false
-    for (const node of document.head.childNodes) {
-      if (node instanceof HTMLMetaElement && node.name === VIEW_TRANSITION) {
-        hasViewTransitionMeta = true
-      }
-    }
-
-    if (!hasViewTransitionMeta) {
-      const meta = document.createElement('meta')
-      meta.name = VIEW_TRANSITION
-      meta.content = 'same-origin'
-      document.head.appendChild(meta)
-    }
-  },
   onLoad: ({ effect, el, genRX }) => {
     if (!supportsViewTransitions) {
       console.error('Browser does not support view transitions')

--- a/library/src/plugins/official/browser/attributes/viewTransition.ts
+++ b/library/src/plugins/official/browser/attributes/viewTransition.ts
@@ -10,8 +10,6 @@ import {
 } from '../../../../engine/types'
 import { supportsViewTransitions } from '../../../../utils/view-transtions'
 
-const VIEW_TRANSITION = 'view-transition'
-
 export const ViewTransition: AttributePlugin = {
   type: PluginType.Attribute,
   name: 'viewTransition',


### PR DESCRIPTION
The meta tag for enabling view transitions is deprecated; it was only used by old versions of Chrome when the experimental feature flag was required to enable view transitions. 

Per the [draft spec] (https://drafts.csswg.org/css-view-transitions-2/), cross document view transitions should be enabled via the CSS rule `@view-transitions`.

Thus, I believe this datastar plugin should no longer append this element to the document head as it's mostly runtime ineffective code. This should also have the added benefit of saving a few bytes from the bundle. 